### PR TITLE
Fix `TaxReductionType` and `FilterCustomers` backed enums values

### DIFF
--- a/src/Enum/FilterCustomers.php
+++ b/src/Enum/FilterCustomers.php
@@ -5,7 +5,7 @@ namespace DeployHuman\fortnox\Enum;
 
 enum FilterCustomers: string
 {
-    case ACTIVE = "ACTIVE";
+    case ACTIVE = "active";
 
-    case INACTIVE = "INACTIVE";
+    case INACTIVE = "inactive";
 }

--- a/src/Enum/TaxReductionType.php
+++ b/src/Enum/TaxReductionType.php
@@ -2,14 +2,13 @@
 
 namespace DeployHuman\fortnox\Enum;
 
-
 enum TaxReductionType: string
 {
-    case NONE = "NONE";
+    case NONE = "none";
 
-    case ROT = "ROT";
+    case ROT = "rot";
 
-    case RUT = "RUT";
+    case RUT = "rut";
 
-    case GREEN = "GREEN";
+    case GREEN = "green";
 }


### PR DESCRIPTION
This PR fixed a potential issue with `TaxReductionType` and `FilterCustomers`. According to the API documentation, these enums expect a lowercased string. The enums in questions can be found under the [Retrieve a list of customers](https://apps.fortnox.se/apidocs#operation/list_CustomersResource) query parameters section and [Create an invoice](https://apps.fortnox.se/apidocs#operation/list_CustomersResource) **payload** section.

Other enums match their expected values as far as I can see. This PR is untested but does follow the API providers' documentation.